### PR TITLE
UpdateOracle no longer requires new authority to be signer

### DIFF
--- a/clients/rust/src/generated/instructions/update_oracle.rs
+++ b/clients/rust/src/generated/instructions/update_oracle.rs
@@ -62,7 +62,7 @@ impl UpdateOracle {
         if let Some(new_authority) = self.new_authority {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
                 new_authority,
-                true,
+                false,
             ));
         } else {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -71,8 +71,8 @@ impl UpdateOracle {
             ));
         }
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&UpdateOracleInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = UpdateOracleInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -93,6 +93,10 @@ impl UpdateOracleInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 13 }
     }
+
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for UpdateOracleInstructionData {
@@ -107,6 +111,12 @@ pub struct UpdateOracleInstructionArgs {
     pub feed_args: Option<FeedArgs>,
 }
 
+impl UpdateOracleInstructionArgs {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
+}
+
 /// Instruction builder for `UpdateOracle`.
 ///
 /// ### Accounts:
@@ -116,7 +126,7 @@ pub struct UpdateOracleInstructionArgs {
 ///   2. `[signer]` authority
 ///   3. `[]` price_feed
 ///   4. `[writable]` oracle
-///   5. `[signer, optional]` new_authority
+///   5. `[optional]` new_authority
 #[derive(Clone, Debug, Default)]
 pub struct UpdateOracleBuilder {
     controller: Option<solana_pubkey::Pubkey>,
@@ -307,7 +317,7 @@ impl<'a, 'b> UpdateOracleCpi<'a, 'b> {
         if let Some(new_authority) = self.new_authority {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
                 *new_authority.key,
-                true,
+                false,
             ));
         } else {
             accounts.push(solana_instruction::AccountMeta::new_readonly(
@@ -322,8 +332,8 @@ impl<'a, 'b> UpdateOracleCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&UpdateOracleInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = UpdateOracleInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {
@@ -362,7 +372,7 @@ impl<'a, 'b> UpdateOracleCpi<'a, 'b> {
 ///   2. `[signer]` authority
 ///   3. `[]` price_feed
 ///   4. `[writable]` oracle
-///   5. `[signer, optional]` new_authority
+///   5. `[optional]` new_authority
 #[derive(Clone, Debug)]
 pub struct UpdateOracleCpiBuilder<'a, 'b> {
     instruction: Box<UpdateOracleCpiBuilderInstruction<'a, 'b>>,

--- a/clients/ts/src/generated/instructions/updateOracle.ts
+++ b/clients/ts/src/generated/instructions/updateOracle.ts
@@ -77,8 +77,7 @@ export type UpdateOracleInstruction<
         ? WritableAccount<TAccountOracle>
         : TAccountOracle,
       TAccountNewAuthority extends string
-        ? ReadonlySignerAccount<TAccountNewAuthority> &
-            AccountSignerMeta<TAccountNewAuthority>
+        ? ReadonlyAccount<TAccountNewAuthority>
         : TAccountNewAuthority,
       ...TRemainingAccounts,
     ]
@@ -133,7 +132,7 @@ export type UpdateOracleInput<
   authority: TransactionSigner<TAccountAuthority>;
   priceFeed: Address<TAccountPriceFeed>;
   oracle: Address<TAccountOracle>;
-  newAuthority?: TransactionSigner<TAccountNewAuthority>;
+  newAuthority?: Address<TAccountNewAuthority>;
   feedArgs: UpdateOracleInstructionDataArgs['feedArgs'];
 };
 

--- a/idl/svm_alm_controller.json
+++ b/idl/svm_alm_controller.json
@@ -674,7 +674,7 @@
         {
           "name": "newAuthority",
           "isMut": false,
-          "isSigner": true,
+          "isSigner": false,
           "isOptional": true
         }
       ],

--- a/integration_tests/tests/subs/oracle.rs
+++ b/integration_tests/tests/subs/oracle.rs
@@ -161,14 +161,14 @@ pub fn update_oracle(
     oracle_pda: &Pubkey,
     price_feed: &Pubkey,
     feed_args: Option<FeedArgs>,
-    new_authority: Option<&Keypair>,
+    new_authority: Option<&Pubkey>,
 ) -> (
     Result<TransactionMetadata, FailedTransactionMetadata>,
     Transaction,
 ) {
     let controller_authority = derive_controller_authority_pda(controller);
 
-    let new_authority_pubkey = new_authority.map(|k| k.pubkey());
+    let new_authority_pubkey = new_authority.map(|k| *k);
     let ixn = if let Some(feed_args) = feed_args {
         UpdateOracleBuilder::new()
             .controller(*controller)
@@ -190,10 +190,7 @@ pub fn update_oracle(
             .instruction()
     };
 
-    let signing_keypairs: Vec<&Keypair> = match new_authority {
-        Some(new_auth) => vec![authority, new_auth],
-        None => vec![authority],
-    };
+    let signing_keypairs: Vec<&Keypair> = vec![authority];
 
     let txn = Transaction::new_signed_with_payer(
         &[ixn],

--- a/integration_tests/tests/test_oracle.rs
+++ b/integration_tests/tests/test_oracle.rs
@@ -130,7 +130,7 @@ mod tests {
             &oracle_pda,
             &new_feed,
             None, // keep oracle_type unchanged.
-            Some(&authority2),
+            Some(&authority2.pubkey()),
         );
 
         let meta = tx_result.map_err(|e| e.err.to_string())?;
@@ -371,7 +371,7 @@ mod tests {
         let txn = Transaction::new_signed_with_payer(
             &[ixn],
             Some(&authority.pubkey()),
-            &[&authority, &authority2],
+            &[&authority],
             svm.latest_blockhash(),
         );
         let tx_result = svm.send_transaction(txn);

--- a/program/src/instructions.rs
+++ b/program/src/instructions.rs
@@ -140,7 +140,7 @@ pub enum SvmAlmControllerInstruction {
     #[account(2, signer, name = "authority")]
     #[account(3, name = "price_feed")]
     #[account(4, writable, name = "oracle")]
-    #[account(5, optional, signer, name = "new_authority")]
+    #[account(5, optional, name = "new_authority")]
     UpdateOracle(UpdateOracleArgs),
 
     /// RefreshOracle

--- a/program/src/processor/oracle/update_oracle.rs
+++ b/program/src/processor/oracle/update_oracle.rs
@@ -18,7 +18,8 @@ define_account_struct! {
         authority: signer;
         price_feed;
         oracle: mut, @owner(crate::ID);
-        new_authority: opt_signer;
+        // (Optional) updates authority when present.
+        new_authority;
     }
 }
 


### PR DESCRIPTION
For ticket: https://github.com/orgs/keel-fi/projects/1/views/1?pane=issue&itemId=137285091&issue=keel-fi%7Cprivate-issues%7C111